### PR TITLE
Fix payment selector not returning on iOS

### DIFF
--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -91,8 +91,6 @@ class GooglePayHandler(private val activity: Activity) :
 
     fun loadPaymentData(result: Result, paymentProfileString: String, paymentItems: List<Map<String, Any?>>): Boolean {
 
-        // Only proceed if there is no other request is active
-        if (loadPaymentDataResult != null) return false
         loadPaymentDataResult = result
 
         val paymentProfile = buildPaymentProfile(paymentProfileString, paymentItems)
@@ -117,13 +115,11 @@ class GooglePayHandler(private val activity: Activity) :
                         data?.let { intent ->
                             PaymentData.getFromIntent(intent).let(::handlePaymentSuccess)
                         }
-                        loadPaymentDataResult = null
                         true
                     }
 
                     Activity.RESULT_CANCELED -> {
                         // The user cancelled the payment attempt
-                        loadPaymentDataResult = null
                         true
                     }
 
@@ -131,12 +127,10 @@ class GooglePayHandler(private val activity: Activity) :
                         AutoResolveHelper.getStatusFromIntent(data)?.let { status ->
                             handleError(status.statusCode)
                         }
-                        loadPaymentDataResult = null
                         true
                     }
 
                     else -> {
-                        loadPaymentDataResult = null
                         false
                     }
                 }

--- a/pay_ios/CHANGELOG.md
+++ b/pay_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4 (2021-05-27)
+
+### Fixes
+
+* Fix iOS not returning a result after consecutive payment attempts.
+
 ## 1.0.3 (2021-05-26)
 
 ### Fixes

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -35,7 +35,7 @@ class PaymentHandler: NSObject {
   func startPayment(result: @escaping FlutterResult, paymentConfiguration: String, paymentItems: [[String: Any?]]) {
     
     // Set active payment result
-    paymentResult = paymentResult ?? result
+    paymentResult = result
     
     // Deserialize payment configuration
     guard let paymentRequest = PaymentHandler.createPaymentRequest(from: paymentConfiguration, paymentItems: paymentItems) else {


### PR DESCRIPTION
* Always overwrite the payment result on Android and iOS after a new payment request is initiated
Solves #34 