### PR TITLE
Proposal to allow passing json string configuration to pay buttons

### DIFF
--- a/pay/lib/src/pay.dart
+++ b/pay/lib/src/pay.dart
@@ -34,10 +34,19 @@ class Pay {
   Pay(this._configurations) : _payPlatform = PayMethodChannel();
 
   /// Alternative constructor to create a [Pay] object with a list of
-  /// configurations in [String] format.
+  /// configuration assets in [String] format.
   Pay.withAssets(List<String> configAssets)
       : _payPlatform = PayMethodChannel() {
     _assetInitializationFuture = _loadConfigAssets(configAssets);
+  }
+
+  /// Alternative constructor to create a [Pay] object with a list of
+  /// configurations in [String] format.
+  Pay.withStrings(List<String> configStrings)
+      : _payPlatform = PayMethodChannel() {
+    _configurations = configStrings
+        .map((cs) => PaymentConfiguration.fromJsonString(cs))
+        .toList();
   }
 
   /// Load the list of configurations from the assets.

--- a/pay/lib/src/widgets/apple_pay_button.dart
+++ b/pay/lib/src/widgets/apple_pay_button.dart
@@ -25,7 +25,8 @@ class ApplePayButton extends PayButton {
 
   ApplePayButton({
     Key? key,
-    required String paymentConfigurationAsset,
+    String? paymentConfigurationAsset,
+    String? paymentConfigurationString,
     required void Function(Map<String, dynamic> result) onPaymentResult,
     required List<PaymentItem> paymentItems,
     ApplePayButtonStyle style = ApplePayButtonStyle.black,
@@ -42,6 +43,7 @@ class ApplePayButton extends PayButton {
         super(
           key,
           paymentConfigurationAsset,
+          paymentConfigurationString,
           onPaymentResult,
           width,
           height,

--- a/pay/lib/src/widgets/google_pay_button.dart
+++ b/pay/lib/src/widgets/google_pay_button.dart
@@ -25,7 +25,8 @@ class GooglePayButton extends PayButton {
 
   GooglePayButton({
     Key? key,
-    required String paymentConfigurationAsset,
+    String? paymentConfigurationAsset,
+    String? paymentConfigurationString,
     required void Function(Map<String, dynamic> result) onPaymentResult,
     required List<PaymentItem> paymentItems,
     GooglePayButtonStyle style = GooglePayButtonStyle.black,
@@ -42,6 +43,7 @@ class GooglePayButton extends PayButton {
         super(
           key,
           paymentConfigurationAsset,
+          paymentConfigurationString,
           onPaymentResult,
           width,
           height,

--- a/pay/lib/src/widgets/pay_button.dart
+++ b/pay/lib/src/widgets/pay_button.dart
@@ -51,7 +51,8 @@ abstract class PayButton extends StatefulWidget {
   /// Initializes the button and the payment client that handles the requests.
   PayButton(
     Key? key,
-    String paymentConfigurationAsset,
+    String? paymentConfigurationAsset,
+    String? paymentConfigurationString,
     this.onPaymentResult,
     this.width,
     this.height,
@@ -59,8 +60,16 @@ abstract class PayButton extends StatefulWidget {
     this.onError,
     this.childOnError,
     this.loadingIndicator,
-  )   : _payClient = Pay.withAssets([paymentConfigurationAsset]),
-        super(key: key);
+  ) : super(key: key) {
+    if (paymentConfigurationAsset != null) {
+      _payClient = Pay.withAssets([paymentConfigurationAsset]);
+    } else if (paymentConfigurationString != null) {
+      _payClient = Pay.withStrings([paymentConfigurationString]);
+    } else {
+      throw Exception(
+          "No configuration provided. Either a 'paymentConfigurationAsset' or a 'paymentConfigurationString' must be passed in as an argument.");
+    }
+  }
 
   /// Callback function to respond to tap events.
   ///

--- a/pay/test/pay_test.dart
+++ b/pay/test/pay_test.dart
@@ -45,5 +45,11 @@ void main() {
     expect(client, isNotNull);
   });
 
+  test('A Pay client can load configuration from a string', () async {
+    final configString = _fixtureAsset('google_pay_default_payment_profile.json');
+    final client = Pay.withStrings([configString]);
+    expect(client, isNotNull);
+  });
+
   tearDown(() async {});
 }


### PR DESCRIPTION
One proposal that allows the _GooglePayButton_, _ApplePayButton_, and _PayButton_ to accept a string which can either be the payment configuration or the payment configuration file.

#7 