### PR TITLE
Expose the class PaymentConfiguration up to the main package

### DIFF
--- a/pay/lib/pay.dart
+++ b/pay/lib/pay.dart
@@ -15,7 +15,7 @@ import 'package:pay_platform_interface/pay_channel.dart';
 import 'package:pay_platform_interface/pay_platform_interface.dart';
 
 export 'package:pay_platform_interface/core/payment_configuration.dart'
-    show PayProvider;
+    show PayProvider, PaymentConfiguration;
 
 export 'package:pay_platform_interface/core/payment_item.dart'
     show PaymentItem, PaymentItemType, PaymentItemStatus;


### PR DESCRIPTION
The advanced integration path offers creating a `Pay` client from a list of configurations, which in turn can be instantiated through the `PaymentConfiguration` class and loaded from an asset or a JSON string. This class was not exposed up to the main package.

FYI #53