### PR TITLE
Add payment canceled exception

### DIFF
--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -183,7 +183,10 @@ class GooglePayHandler(private val activity: Activity) :
                 }
 
                 Activity.RESULT_CANCELED -> {
-                    // The user cancelled the payment attempt
+                    loadPaymentDataResult!!.error(
+                            "paymentCanceled",
+                            "User canceled payment authorisation.",
+                            null)
                     true
                 }
 

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -185,7 +185,7 @@ class GooglePayHandler(private val activity: Activity) :
                 Activity.RESULT_CANCELED -> {
                     loadPaymentDataResult!!.error(
                             "paymentCanceled",
-                            "User canceled payment authorisation.",
+                            "User canceled payment authorization",
                             null)
                     true
                 }

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -21,6 +21,11 @@ import UIKit
 /// An alias to determine the result types of a payment operation.
 typealias PaymentCompletionHandler = (Bool) -> Void
 
+/// Enum to track payment handler status and result
+enum PaymentHandlerStatus {
+  case started, presented, authorizationStarted, authorized
+}
+
 /// A simple helper to orchestrate fundamental calls to complete a payment operation.
 ///
 /// Use this class to manage payment sessions, with the ability to determine whether a user
@@ -33,7 +38,7 @@ typealias PaymentCompletionHandler = (Bool) -> Void
 class PaymentHandler: NSObject {
   
   /// Holds the current status of the payment process.
-  var paymentStatus = PKPaymentAuthorizationStatus.failure
+  var paymentHandlerStatus: PaymentHandlerStatus = .started
   
   /// Stores a reference to the Flutter result while the operation completes.
   var paymentResult: FlutterResult!
@@ -66,17 +71,22 @@ class PaymentHandler: NSObject {
     // Set active payment result.
     paymentResult = result
     
+    // Reset payment handler status
+    paymentHandlerStatus = .started
+    
     // Deserialize payment configuration.
     guard let paymentRequest = PaymentHandler.createPaymentRequest(from: paymentConfiguration, paymentItems: paymentItems) else {
       result(FlutterError(code: "invalidPaymentConfiguration", message: "It was not possible to create a payment request from the provided configuration. Review your payment configuration and run again", details: nil))
       return
     }
     
-    // Display the payment selector with the resquest created.
+    // Display the payment selector with the request created.
     let paymentController = PKPaymentAuthorizationController(paymentRequest: paymentRequest)
     paymentController.delegate = self
     paymentController.present(completion: { (presented: Bool) in
-      if !presented {
+      if presented {
+        self.paymentHandlerStatus = .presented
+      } else {
         result(FlutterError(code: "paymentError", message: "Failed to present payment controller", details: nil))
       }
     })
@@ -168,6 +178,11 @@ class PaymentHandler: NSObject {
 
 /// Extension that implements the completion methods in the delegate to respond to user selection.
 extension PaymentHandler: PKPaymentAuthorizationControllerDelegate {
+
+  func paymentAuthorizationControllerWillAuthorizePayment(_ controller: PKPaymentAuthorizationController) {
+      paymentHandlerStatus = .authorizationStarted
+  }
+    
   func paymentAuthorizationController(_: PKPaymentAuthorizationController, didAuthorizePayment payment: PKPayment, handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
     
     // Collect payment result or error and return if no payment was selected
@@ -179,14 +194,20 @@ extension PaymentHandler: PKPaymentAuthorizationControllerDelegate {
     // Return the result back to the channel
     self.paymentResult(String(decoding: paymentResultData, as: UTF8.self))
     
-    paymentStatus = .success
-    completion(PKPaymentAuthorizationResult(status: paymentStatus, errors: nil))
+    paymentHandlerStatus = .authorized
+
+    completion(PKPaymentAuthorizationResult(status: PKPaymentAuthorizationStatus.success, errors: nil))
   }
   
   func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
     controller.dismiss {
       DispatchQueue.main.async {
-        if self.paymentStatus != .success {
+        // There was no attempt to authorize.
+        if self.paymentHandlerStatus == .presented {
+          self.paymentResult(FlutterError(code: "paymentCanceled", message: "User canceled payment authorization", details: nil))
+        }
+        // Authorization started, but it did not succeed
+        if self.paymentHandlerStatus == .authorizationStarted {
           self.paymentResult(FlutterError(code: "paymentFailed", message: "Failed to complete the payment", details: nil))
         }
       }

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -23,7 +23,7 @@ typealias PaymentCompletionHandler = (Bool) -> Void
 
 /// Enum to track payment handler status and result
 enum PaymentHandlerStatus {
-  case started, presented, authorizationStarted, authorized
+  case started, presented, authorizationStarted
 }
 
 /// A simple helper to orchestrate fundamental calls to complete a payment operation.
@@ -38,7 +38,7 @@ enum PaymentHandlerStatus {
 class PaymentHandler: NSObject {
   
   /// Holds the current status of the payment process.
-  var paymentHandlerStatus: PaymentHandlerStatus = .started
+  var paymentHandlerStatus: PaymentHandlerStatus!
   
   /// Stores a reference to the Flutter result while the operation completes.
   var paymentResult: FlutterResult!
@@ -67,10 +67,10 @@ class PaymentHandler: NSObject {
   /// - parameter paymentItems: A list of payment elements that determine the total amount purchased.
   /// - returns: The payment method information selected by the user.
   func startPayment(result: @escaping FlutterResult, paymentConfiguration: String, paymentItems: [[String: Any?]]) {
-    
+
     // Set active payment result.
     paymentResult = result
-    
+
     // Reset payment handler status
     paymentHandlerStatus = .started
     
@@ -194,8 +194,6 @@ extension PaymentHandler: PKPaymentAuthorizationControllerDelegate {
     // Return the result back to the channel
     self.paymentResult(String(decoding: paymentResultData, as: UTF8.self))
     
-    paymentHandlerStatus = .authorized
-
     completion(PKPaymentAuthorizationResult(status: PKPaymentAuthorizationStatus.success, errors: nil))
   }
   

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -23,7 +23,7 @@ typealias PaymentCompletionHandler = (Bool) -> Void
 
 /// Enum to track payment handler status and result
 enum PaymentHandlerStatus {
-  case started, presented, authorizationStarted
+  case started, presented, authorizationStarted, authorized
 }
 
 /// A simple helper to orchestrate fundamental calls to complete a payment operation.
@@ -194,6 +194,7 @@ extension PaymentHandler: PKPaymentAuthorizationControllerDelegate {
     // Return the result back to the channel
     self.paymentResult(String(decoding: paymentResultData, as: UTF8.self))
     
+    paymentHandlerStatus = .authorized
     completion(PKPaymentAuthorizationResult(status: PKPaymentAuthorizationStatus.success, errors: nil))
   }
   


### PR DESCRIPTION
👋 Hi,

as outlined in #61, it would be nice to have consistent feedback when the user cancels payment authorization by closing the native payment selector.

The proposed changes end up throwing a `PlatformException(code: 'paymentCanceled')`.
The Android implementation is straightforward, as `Activity.RESULT_CANCELED` makes it obvious when the user canceled.

The iOS implementation is more involved, as it requires a more detailed tracking via delegate methods to make sure that the user canceled voluntarily, i.e. user canceled if:
- native payment selector was shown (`paymentAuthorizationControllerWillAuthorizePayment`)
- user _does not try to authorize a payment_ (`didAuthorizePayment`)
- native payment selector is closed (`paymentAuthorizationControllerDidFinish`)

The implementation also fixes #77.