### PR TITLE
Prevents decimal conversion issues with certain locales

### DIFF
--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -119,16 +119,11 @@ class PaymentHandler: NSObject {
     // Create payment request and include summary items
     let paymentRequest = PKPaymentRequest()
     paymentRequest.paymentSummaryItems = paymentItems.map { item in
-      if let statusString = item["status"] {
-        return PKPaymentSummaryItem(
-          label: item["label"] as! String ,
-          amount: NSDecimalNumber(string: (item["amount"] as! String)),
-          type: PKPaymentSummaryItemType.fromString(statusString as! String))
-      }
-      
       return PKPaymentSummaryItem(
         label: item["label"] as! String,
-        amount: NSDecimalNumber(string: (item["amount"] as! String)))
+        amount: NSDecimalNumber(value: Double(item["amount"] as! String)!),
+        type: (PKPaymentSummaryItemType.fromString(item["status"] as? String ?? "final_price"))
+      )
     }
     
     // Configure the payment.

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -304,10 +304,10 @@ extension PKPaymentSummaryItemType {
   /// Creates a `PKPaymentSummaryItemType` object from an item type in string format.
   public static func fromString(_ summaryItemType: String) -> PKPaymentSummaryItemType {
     switch summaryItemType {
-    case "final_price":
-      return .final
-    default:
+    case "pending":
       return .pending
+    default:
+      return .final // final_price
     }
   }
 }

--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -121,7 +121,7 @@ class PaymentHandler: NSObject {
     paymentRequest.paymentSummaryItems = paymentItems.map { item in
       return PKPaymentSummaryItem(
         label: item["label"] as! String,
-        amount: NSDecimalNumber(value: Double(item["amount"] as! String)!),
+        amount: NSDecimalNumber(string: (item["amount"] as! String), locale:["NSLocaleDecimalSeparator": "."]),
         type: (PKPaymentSummaryItemType.fromString(item["status"] as? String ?? "final_price"))
       )
     }


### PR DESCRIPTION
/cc @kristoffer-zliide
Addresses #84.

* Uses `Decimal` to be consistent about the decimal separator (.)
* Default to the `final` payment method type if not specified