### PR TITLE
feat(pay_ios): Add PostalAddress Data to Billing and Shipping Contact

### DIFF
--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -250,7 +250,26 @@ extension PKContact {
     return [
       "name": "\(name?.givenName ?? "") \(name?.familyName ?? "")",
       "emailAddress": emailAddress,
-      "phoneNumber": phoneNumber?.stringValue
+      "phoneNumber": phoneNumber?.stringValue,
+      "postalAddress": postalAddress?.toDictionary()
+    ]
+  }
+}
+
+/// A set of utility methods associated wo `CNPostalAddress`
+extension CNPostalAddress {
+
+  // Creates a `Dictionary` representation of the `CNPostalAddress` object
+  public func toDictionary() -> [String: Any?] {
+    return [
+      "street": street,
+      "city": city,
+      "state": state,
+      "postalCode": postalCode,
+      "country": country,
+      "isoCountryCode": isoCountryCode,
+      "subAdministrativeArea": subAdministrativeArea,
+      "subLocality": subLocality
     ]
   }
 }


### PR DESCRIPTION
To be able to process the data returned by the PaymentResult, the address data should be returned to the Client too.
It will be added to the contact as a dictionary entry.