### PR TITLE
Use local files for example's transitive deps

### DIFF
--- a/pay/example/pubspec.yaml
+++ b/pay/example/pubspec.yaml
@@ -36,6 +36,14 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.3
 
+dependency_overrides:
+  pay_android:
+    path: ../../pay_android
+  pay_ios:
+    path: ../../pay_ios
+  pay_platform_interface:
+    path: ../../pay_platform_interface
+
 dev_dependencies:
   integration_test:
    sdk: flutter


### PR DESCRIPTION
The example app is configured to use the local version of the `pay` package:

https://github.com/google-pay/flutter-plugin/blob/4fa27d44ffe205581eded7e2c4a91263a4225d36/pay/example/pubspec.yaml#L32-L33

Problem is: the dependencies of the `pay` package (i.e. `pay_ios`, `pay_android` and `pay_platform_interface`) are still the ones published on pub.dev.

This PR forces the example app to also use the local versions of those dependencies, so it makes native changes easier to test in the example app.

Other plugins following the same pattern for their example apps:
- "Plus" plugins: "https://github.com/fluttercommunity/plus_plugins/blob/main/packages/device_info_plus/device_info_plus/example/pubspec.yaml
- Firebase: https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml