### PR TITLE
[PR] Add cornerRadius to ApplePayButtonView (issues#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+flutter-pay-plugin
+Fork Google Flutter Pay Plugin for Apple Pay and Google Pay
+
+
+## Apple Pay
+This plugin is used to introduce Apple Pay in SNCF CONNECT flutter app
+
+## Why fork ?
+- Customize cornerRadius Apple Pay Button (https://github.com/google-pay/flutter-plugin/issues/127)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-flutter-pay-plugin
+## flutter-pay-plugin
 Fork Google Flutter Pay Plugin for Apple Pay and Google Pay
 
 

--- a/pay/example/lib/main.dart
+++ b/pay/example/lib/main.dart
@@ -146,6 +146,7 @@ class _PaySampleAppState extends State<PaySampleApp> {
             paymentItems: _paymentItems,
             style: ApplePayButtonStyle.black,
             type: ApplePayButtonType.buy,
+            cornerRadius: 24.0,
             margin: const EdgeInsets.only(top: 15.0),
             onPaymentResult: onApplePayResult,
             loadingIndicator: const Center(

--- a/pay/lib/src/widgets/apple_pay_button.dart
+++ b/pay/lib/src/widgets/apple_pay_button.dart
@@ -34,6 +34,7 @@ class ApplePayButton extends PayButton {
     ApplePayButtonType type = ApplePayButtonType.plain,
     double width = RawApplePayButton.minimumButonWidth,
     double height = RawApplePayButton.minimumButtonHeight,
+    double cornerRadius = RawApplePayButton.defaultCornerRadius,
     EdgeInsets margin = EdgeInsets.zero,
     VoidCallback? onPressed,
     void Function(Object? error)? onError,
@@ -57,6 +58,7 @@ class ApplePayButton extends PayButton {
     _applePayButton = RawApplePayButton(
         style: style,
         type: type,
+        cornerRadius: cornerRadius,
         onPressed: _defaultOnPressed(onPressed, paymentItems));
   }
 

--- a/pay_ios/ios/Classes/ApplePayButtonView.swift
+++ b/pay_ios/ios/Classes/ApplePayButtonView.swift
@@ -112,6 +112,7 @@ class ApplePayButtonView: NSObject, FlutterPlatformView {
     let arguments = args as! Dictionary<String, AnyObject>
     let buttonType = arguments["type"] as! String
     let buttonStyle = arguments["style"] as! String
+    let cornerRadius = arguments["cornerRadius"] as! Double
     
     // Instantiate the channel to talk to the Flutter end.
     channel = FlutterMethodChannel(name: "\(ApplePayButtonView.buttonMethodChannelName)/\(viewId)",
@@ -119,7 +120,7 @@ class ApplePayButtonView: NSObject, FlutterPlatformView {
     
     super.init()
     channel.setMethodCallHandler(handleFlutterCall)
-    createApplePayView(type: buttonType, style: buttonStyle)
+    createApplePayView(type: buttonType, style: buttonStyle, radius: cornerRadius)
   }
   
   /// No-op handler that resonds to calls received from Flutter.
@@ -138,7 +139,7 @@ class ApplePayButtonView: NSObject, FlutterPlatformView {
   }
   
   /// Creates the actual `PKPaymentButton` with the defined styles and constraints.
-  func createApplePayView(type buttonTypeString: String, style buttonStyleString: String){
+  func createApplePayView(type buttonTypeString: String, style buttonStyleString: String, radius cornerRadius: Double){
     
     // Create the PK objects
     let paymentButtonType = PKPaymentButtonType.fromString(buttonTypeString) ?? .plain
@@ -150,6 +151,9 @@ class ApplePayButtonView: NSObject, FlutterPlatformView {
     applePayButton.addTarget(self, action: #selector(handleApplePayButtonTapped), for: .touchUpInside)
     _view.addSubview(applePayButton)
     
+    if #available(iOS 12.0, *) {
+      applePayButton.cornerRadius = CGFloat(cornerRadius)
+    }
     // Enable constraints
     applePayButton.topAnchor.constraint(equalTo: _view.topAnchor).isActive = true
     applePayButton.bottomAnchor.constraint(equalTo: _view.bottomAnchor).isActive = true

--- a/pay_ios/lib/src/widgets/apple_pay_button.dart
+++ b/pay_ios/lib/src/widgets/apple_pay_button.dart
@@ -78,6 +78,10 @@ class RawApplePayButton extends StatelessWidget {
   /// The default height for the Apple Pay Button.
   static const double minimumButtonHeight = 30;
 
+  /// The default cornerRadius for the Apple Pay Button. 
+  /// (https://developer.apple.com/documentation/passkit/pkpaymentbutton/2999416-cornerradius)
+  static const double defaultCornerRadius = 4;
+
   /// The constraints used to limit the size of the button.
   final BoxConstraints constraints;
 
@@ -92,12 +96,16 @@ class RawApplePayButton extends StatelessWidget {
   /// transaction.
   final ApplePayButtonType type;
 
+  /// The cornerRadius of the Apple Pay button
+  final double cornerRadius;
+
   /// Creates an Apple Pay button widget with the parameters specified.
   RawApplePayButton({
     Key? key,
     this.onPressed,
     this.style = ApplePayButtonStyle.black,
     this.type = ApplePayButtonType.plain,
+    this.cornerRadius = RawApplePayButton.defaultCornerRadius,
   })  : constraints = BoxConstraints.tightFor(
           width: type.minimumAssetWidth,
           height: minimumButtonHeight,
@@ -122,6 +130,7 @@ class RawApplePayButton extends StatelessWidget {
           onPressed: onPressed,
           style: style,
           type: type,
+          cornerRadius: cornerRadius,
         );
       default:
         throw UnsupportedError(
@@ -140,12 +149,14 @@ class _UiKitApplePayButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final ApplePayButtonStyle style;
   final ApplePayButtonType type;
+  final double cornerRadius;
 
   _UiKitApplePayButton({
     Key? key,
     this.onPressed,
     this.style = ApplePayButtonStyle.black,
     this.type = ApplePayButtonType.plain,
+    this.cornerRadius = RawApplePayButton.defaultCornerRadius,
   }) : super(key: key);
 
   @override
@@ -153,7 +164,7 @@ class _UiKitApplePayButton extends StatelessWidget {
     return UiKitView(
       viewType: buttonId,
       creationParamsCodec: const StandardMessageCodec(),
-      creationParams: {'style': style.enumString, 'type': type.enumString},
+      creationParams: {'style': style.enumString, 'type': type.enumString, 'cornerRadius': cornerRadius},
       onPlatformViewCreated: (viewId) {
         methodChannel = MethodChannel('$buttonId/$viewId');
         methodChannel?.setMethodCallHandler((call) async {


### PR DESCRIPTION
## Customize Apple Pay Button (cornerRadius)

The goal of this PR is to enable customization of **ApplePayButton** cornerRadius

By default the value is set to 4.0 (https://developer.apple.com/documentation/passkit/pkpaymentbutton/2999416-cornerradius) but we are able to override this value.

So in this PR we add a new attribute `cornerRadius` to custom the Apple Pay Button cornerRadius