### PR TITLE
Adds Android namespace

### DIFF
--- a/pay/example/android/app/build.gradle
+++ b/pay/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'io.flutter.plugins.pay_example'
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/pay_android/CHANGELOG.md
+++ b/pay_android/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 1.0.11 (2023-04-26)
-
-* Adds a `namespace` attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
-
 ## 1.0.10 (2023-02-02)
 
 * Bump `flutter_svg` to version 2.0.5.

--- a/pay_android/CHANGELOG.md
+++ b/pay_android/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.11 (2023-04-26)
+
+* Adds a `namespace` attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
+
 ## 1.0.10 (2023-02-02)
 
 * Bump `flutter_svg` to version 2.0.5.

--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -41,6 +41,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'io.flutter.plugins.pay_android'
     compileSdkVersion 31
 
     compileOptions {

--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -41,7 +41,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'io.flutter.plugins.pay_android'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'io.flutter.plugins.pay_android'
+    }
     compileSdkVersion 31
 
     compileOptions {

--- a/pay_android/pubspec.yaml
+++ b/pay_android/pubspec.yaml
@@ -14,7 +14,7 @@
 
 name: pay_android
 description: A plug-in to add support for payments on the Android side of Flutter applications.
-version: 1.0.11
+version: 1.0.10
 homepage: https://github.com/google-pay/flutter-plugin
 
 environment:

--- a/pay_android/pubspec.yaml
+++ b/pay_android/pubspec.yaml
@@ -14,7 +14,7 @@
 
 name: pay_android
 description: A plug-in to add support for payments on the Android side of Flutter applications.
-version: 1.0.10
+version: 1.0.11
 homepage: https://github.com/google-pay/flutter-plugin
 
 environment:


### PR DESCRIPTION
Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b