### PR TITLE
Remove the activity result listener when the activity is detached from the plugin

### DIFF
--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -71,7 +71,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.android.gms:play-services-wallet:18.1.2'
+    implementation 'com.google.android.gms:play-services-wallet:19.1.0'
 
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:truth:1.5.0'

--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -71,15 +71,15 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.android.gms:play-services-wallet:18.1.2"
+    implementation 'com.google.android.gms:play-services-wallet:18.1.2'
 
-    testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'androidx.test.ext:truth:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'androidx.test.ext:truth:1.5.0'
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:3.6.28'
     testImplementation 'org.robolectric:robolectric:4.4'
 
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.flutter.plugins.pay_android
 
 import android.app.Activity
-import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
@@ -64,7 +63,7 @@ class PayMethodCallHandler private constructor(
     fun stopListening() = channel.setMethodCallHandler(null)
 
     @Suppress("UNCHECKED_CAST")
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             METHOD_USER_CAN_PAY -> googlePayHandler.isReadyToPay(result, call.arguments()!!)
             METHOD_SHOW_PAYMENT_SELECTOR -> {


### PR DESCRIPTION
Addresses #206 
At the moment, when the activity is reclaimed, the listener in the activity binding is not adequately cleared. This may be related to the issue seen in #206.  This PR clears the listener when the activity is detached.