### PR TITLE
Remove `merchantId` from defaultGooglePay

### DIFF
--- a/pay/example/lib/payment_configurations.dart
+++ b/pay/example/lib/payment_configurations.dart
@@ -88,7 +88,6 @@ const String defaultGooglePay = '''{
       }
     ],
     "merchantInfo": {
-      "merchantId": "01234567890123456789",
       "merchantName": "Example Merchant Name"
     },
     "transactionInfo": {


### PR DESCRIPTION
`merchantId` is not specified in googles docs https://developers.google.com/pay/api/android/reference/request-objects#MerchantInfo