### PR TITLE
Fix Issue #235

### DIFF
--- a/pay_ios/lib/src/widgets/apple_pay_button.dart
+++ b/pay_ios/lib/src/widgets/apple_pay_button.dart
@@ -132,7 +132,7 @@ class RawApplePayButton extends StatelessWidget {
 }
 
 /// A widget to draw the Apple Pay button through a [PlatforView].
-class _UiKitApplePayButton extends StatelessWidget {
+class _UiKitApplePayButton extends StatefulWidget {
   static const buttonId = 'plugins.flutter.io/pay/apple_pay_button';
 
   final VoidCallback? onPressed;
@@ -146,15 +146,20 @@ class _UiKitApplePayButton extends StatelessWidget {
   });
 
   @override
+  State<_UiKitApplePayButton> createState() => _UiKitApplePayButtonState();
+}
+
+class _UiKitApplePayButtonState extends State<_UiKitApplePayButton> {
+  @override
   Widget build(BuildContext context) {
     return UiKitView(
-      viewType: buttonId,
+      viewType: _UiKitApplePayButton.buttonId,
       creationParamsCodec: const StandardMessageCodec(),
-      creationParams: {'style': style.enumString, 'type': type.enumString},
+      creationParams: {'style': widget.style.enumString, 'type': widget.type.enumString},
       onPlatformViewCreated: (viewId) {
-        MethodChannel methodChannel = MethodChannel('$buttonId/$viewId');
+        MethodChannel methodChannel = MethodChannel('${_UiKitApplePayButton.buttonId}/$viewId');
         methodChannel.setMethodCallHandler((call) async {
-          if (call.method == 'onPressed') onPressed?.call();
+          if (call.method == 'onPressed') widget.onPressed?.call();
         });
       },
     );


### PR DESCRIPTION
### Bug:
Fixes issue #235 
The current implementation of the ApplePayButton only sets the payment items on create.
Changing the payment items after the button is created doesn't change the callback from onPressed.

### Changes:  
* `_UiKitApplePayButton` sets the callback on each build.
* The example has been updated with quantity, this will show why this PR is needed.

## Before:
Changing quantity didn't change the price

https://github.com/google-pay/flutter-plugin/assets/75931499/760d4083-f28f-4cff-975b-53a66b3dfb8b



## After:
Price changes due to quantity

https://github.com/google-pay/flutter-plugin/assets/75931499/051e8ba2-23da-4086-bab0-a389266e3daf

