### PR TITLE
Make the payment item label required

### DIFF
--- a/pay/example/assets/default_google_pay_config.json
+++ b/pay/example/assets/default_google_pay_config.json
@@ -26,7 +26,6 @@
       }
     ],
     "merchantInfo": {
-      "merchantId": "01234567890123456789",
       "merchantName": "Example Merchant Name"
     },
     "transactionInfo": {

--- a/pay/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/pay/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/pay/example/ios/Podfile
+++ b/pay/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/pay/example/ios/Podfile.lock
+++ b/pay/example/ios/Podfile.lock
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/pay_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
   pay_ios: 8c7beb9c61d885f3f51b61f75f8793023fc8843a
 
-PODFILE CHECKSUM: fc81e398f362bae88bdf55239bd5cf842faad39f
+PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
 COCOAPODS: 1.11.3

--- a/pay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/pay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -170,7 +170,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -237,10 +237,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -268,6 +270,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/pay/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/pay/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/pay_platform_interface/lib/core/payment_item.dart
+++ b/pay_platform_interface/lib/core/payment_item.dart
@@ -73,7 +73,7 @@ extension on PaymentItemType {
 /// ```
 class PaymentItem {
   /// A text with basic information about the item.
-  final String? label;
+  final String label;
 
   ///  The price of the item in string format.
   final String amount;
@@ -88,7 +88,7 @@ class PaymentItem {
   /// a [total] [type], and an [unknown] [status].
   const PaymentItem({
     required this.amount,
-    this.label,
+    required this.label,
     this.type = PaymentItemType.total,
     this.status = PaymentItemStatus.unknown,
   });


### PR DESCRIPTION
The `label` property in the `PaymentItem` class is now required.
The `label` is a mandatory property for Apple Pay. For the time being, this property is ignored on Google Pay.

Related #265.