### PR TITLE
Fixes lateinit property has not been initialized crash 

### DIFF
--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -43,7 +43,7 @@ private const val LOAD_PAYMENT_DATA_REQUEST_CODE = 991
 class GooglePayHandler(private val activity: Activity) :
         PluginRegistry.ActivityResultListener {
 
-    private lateinit var loadPaymentDataResult: Result
+    private var loadPaymentDataResult: Result? = null
 
     companion object {
 
@@ -183,7 +183,7 @@ class GooglePayHandler(private val activity: Activity) :
                 }
 
                 Activity.RESULT_CANCELED -> {
-                    loadPaymentDataResult.error(
+                    loadPaymentDataResult?.error(
                             "paymentCanceled",
                             "User canceled payment authorization",
                             null)
@@ -213,9 +213,9 @@ class GooglePayHandler(private val activity: Activity) :
      */
     private fun handlePaymentSuccess(paymentData: PaymentData?) {
         if (paymentData != null) {
-            loadPaymentDataResult.success(paymentData.toJson())
+            loadPaymentDataResult?.success(paymentData.toJson())
         } else {
-            loadPaymentDataResult.error(
+            loadPaymentDataResult?.error(
                     CommonStatusCodes.INTERNAL_ERROR.toString(),
                     "Unexpected empty result data.",
                     null)
@@ -235,5 +235,5 @@ class GooglePayHandler(private val activity: Activity) :
      * Wallet constants library](https://developers.google.com/android/reference/com/google/android/gms/wallet/WalletConstants.constant-summary)
      */
     private fun handleError(statusCode: Int) =
-            loadPaymentDataResult.error(statusCode.toString(), "", null)
+            loadPaymentDataResult?.error(statusCode.toString(), "", null)
 }


### PR DESCRIPTION
This MR prevents the crash where, in some cases, the lateinit variable is null when onActivityResult is called. To prevent it, it was changed from lateinit to a nullable variable, where the var is checked before using it.

![image](https://github.com/user-attachments/assets/72e07939-5188-49cd-9874-c430c2de1fe0)


` Caused by s9.o: lateinit property loadPaymentDataResult has not been initialized
       at io.flutter.plugins.pay_android.GooglePayHandler.onActivityResult(GooglePayHandler.java:4)
       at io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEngineConnectionRegistry.java:25)
       at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.onActivityResult(FlutterEngineConnectionRegistry.java:13)
       at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.m(FlutterActivityAndFragmentDelegate.java:16)
       at io.flutter.embedding.android.FlutterFragment.onActivityResult(FlutterFragment.java:10)
       at io.flutter.embedding.android.FlutterFragmentActivity.onActivityResult(FlutterFragmentActivity.java:5)
       at android.app.Activity.dispatchActivityResult(Activity.java:9362)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:6055)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:6101)
       at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:67)
       at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2685)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:230)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:8918)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)`
       
 **To prevent the crash when lateinit is null, I changed the variable to nullable and checked it every time that is used, if for some reason the onActivityResult method is called, the app will not break.**