### PR TITLE
Add an event stream to communicate with Android's native end

### DIFF
--- a/pay/example/ios/Runner/Info.plist
+++ b/pay/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/pay/example/lib/advanced.dart
+++ b/pay/example/lib/advanced.dart
@@ -1,0 +1,223 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:pay/pay.dart';
+
+import 'payment_configurations.dart' as payment_configurations;
+
+void main() {
+  runApp(const PayAdvancedMaterialApp());
+}
+
+const googlePayEventChannelName = 'plugins.flutter.io/pay/payment_result';
+const _paymentItems = [
+  PaymentItem(
+    label: 'Total',
+    amount: '99.99',
+    status: PaymentItemStatus.final_price,
+  )
+];
+
+class PayAdvancedMaterialApp extends StatelessWidget {
+  const PayAdvancedMaterialApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Pay for Flutter Advanced Integration Demo',
+      localizationsDelegates: const [
+        ...GlobalMaterialLocalizations.delegates,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en', ''),
+        Locale('es', ''),
+        Locale('de', ''),
+      ],
+      home: PayAdvancedSampleApp(),
+    );
+  }
+}
+
+class PayAdvancedSampleApp extends StatefulWidget {
+  final Pay payClient;
+
+  PayAdvancedSampleApp({super.key})
+      : payClient = Pay({
+          PayProvider.google_pay: payment_configurations.defaultGooglePayConfig,
+          PayProvider.apple_pay: payment_configurations.defaultApplePayConfig,
+        });
+
+  @override
+  State<PayAdvancedSampleApp> createState() => _PayAdvancedSampleAppState();
+}
+
+class _PayAdvancedSampleAppState extends State<PayAdvancedSampleApp> {
+  static const eventChannel = EventChannel(googlePayEventChannelName);
+  StreamSubscription<String>? _googlePayResultSubscription;
+
+  late final Future<bool> _canPayGoogleFuture;
+  late final Future<bool> _canPayAppleFuture;
+
+  // A method to listen to events coming from the event channel on Android
+  void _startListeningForPaymentResults() {
+    _googlePayResultSubscription = eventChannel
+        .receiveBroadcastStream()
+        .map((result) => result.toString())
+        .listen(debugPrint, onError: (error) => debugPrint(error.toString()));
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      _startListeningForPaymentResults();
+    }
+
+    // Initialize userCanPay futures
+    _canPayGoogleFuture = widget.payClient.userCanPay(PayProvider.google_pay);
+    _canPayAppleFuture = widget.payClient.userCanPay(PayProvider.apple_pay);
+  }
+
+  void _onGooglePayPressed() =>
+      _showPaymentSelectorForProvider(PayProvider.google_pay);
+
+  void _onApplePayPressed() =>
+      _showPaymentSelectorForProvider(PayProvider.apple_pay);
+
+  void _showPaymentSelectorForProvider(PayProvider provider) async {
+    try {
+      final result =
+          await widget.payClient.showPaymentSelector(provider, _paymentItems);
+      debugPrint(result.toString());
+    } catch (error) {
+      debugPrint(error.toString());
+    }
+  }
+
+  @override
+  void dispose() {
+    _googlePayResultSubscription?.cancel();
+    _googlePayResultSubscription = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('T-shirt Shop'),
+      ),
+      backgroundColor: Colors.white,
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        children: [
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 20),
+            child: const Image(
+              image: AssetImage('assets/images/ts_10_11019a.jpg'),
+              height: 350,
+            ),
+          ),
+          const Text(
+            'Amanda\'s Polo Shirt',
+            style: TextStyle(
+              fontSize: 20,
+              color: Color(0xff333333),
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 5),
+          const Text(
+            '\$50.20',
+            style: TextStyle(
+              color: Color(0xff777777),
+              fontSize: 15,
+            ),
+          ),
+          const SizedBox(height: 15),
+          const Text(
+            'Description',
+            style: TextStyle(
+              fontSize: 15,
+              color: Color(0xff333333),
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 5),
+          const Text(
+            'A versatile full-zip that you can wear all day long and even...',
+            style: TextStyle(
+              color: Color(0xff777777),
+              fontSize: 15,
+            ),
+          ),
+
+          // Google Pay button
+          FutureBuilder<bool>(
+            future: _canPayGoogleFuture,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.data == true) {
+                  return RawGooglePayButton(
+                      paymentConfiguration:
+                          payment_configurations.defaultGooglePayConfig,
+                      type: GooglePayButtonType.buy,
+                      onPressed: _onGooglePayPressed);
+                } else {
+                  // userCanPay returned false
+                  // Consider showing an alternative payment method
+                }
+              } else {
+                // The operation hasn't finished loading
+                // Consider showing a loading indicator
+              }
+              // This example shows an empty box if userCanPay returns false
+              return const SizedBox.shrink();
+            },
+          ),
+
+          // Apple Pay button
+          FutureBuilder<bool>(
+            future: _canPayAppleFuture,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.data == true) {
+                  return RawApplePayButton(
+                      type: ApplePayButtonType.buy,
+                      onPressed: _onApplePayPressed);
+                } else {
+                  // userCanPay returned false
+                  // Consider showing an alternative payment method
+                }
+              } else {
+                // The operation hasn't finished loading
+                // Consider showing a loading indicator
+              }
+              // This example shows an empty box if userCanPay returns false
+              return const SizedBox.shrink();
+            },
+          ),
+          const SizedBox(height: 15)
+        ],
+      ),
+    );
+  }
+}

--- a/pay/example/lib/advanced.dart
+++ b/pay/example/lib/advanced.dart
@@ -169,6 +169,7 @@ class _PayAdvancedSampleAppState extends State<PayAdvancedSampleApp> {
               fontSize: 15,
             ),
           ),
+          const SizedBox(height: 15),
 
           // Google Pay button
           FutureBuilder<bool>(
@@ -215,7 +216,6 @@ class _PayAdvancedSampleAppState extends State<PayAdvancedSampleApp> {
               return const SizedBox.shrink();
             },
           ),
-          const SizedBox(height: 15)
         ],
       ),
     );

--- a/pay/example/lib/payment_configurations.dart
+++ b/pay/example/lib/payment_configurations.dart
@@ -23,6 +23,12 @@
 /// application.
 library;
 
+import 'package:pay/pay.dart';
+
+/// Sample [PaymentConfiguration] for Apple Pay
+final defaultApplePayConfig =
+    PaymentConfiguration.fromJsonString(defaultApplePay);
+
 /// Sample configuration for Apple Pay. Contains the same content as the file
 /// under `assets/default_payment_profile_apple_pay.json`.
 const String defaultApplePay = '''{
@@ -58,6 +64,10 @@ const String defaultApplePay = '''{
     ]
   }
 }''';
+
+/// Sample [PaymentConfiguration] for Google Pay
+final defaultGooglePayConfig =
+    PaymentConfiguration.fromJsonString(defaultGooglePay);
 
 /// Sample configuration for Google Pay. Contains the same content as the file
 /// under `assets/default_payment_profile_google_pay.json`.

--- a/pay/lib/pay.dart
+++ b/pay/lib/pay.dart
@@ -14,10 +14,12 @@
 
 library pay;
 
+import 'dart:convert';
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:pay_ios/pay_ios.dart';
 import 'package:pay_android/pay_android.dart';
 import 'package:pay_platform_interface/core/payment_configuration.dart';

--- a/pay/lib/src/widgets/apple_pay_button.dart
+++ b/pay/lib/src/widgets/apple_pay_button.dart
@@ -66,5 +66,5 @@ class ApplePayButton extends PayButton {
   late final Widget _payButton = _applePayButton;
 
   @override
-  final bool _returnsPaymentDataSynchronously = true;
+  final bool _collectPaymentResultSynchronously = true;
 }

--- a/pay/lib/src/widgets/apple_pay_button.dart
+++ b/pay/lib/src/widgets/apple_pay_button.dart
@@ -64,4 +64,7 @@ class ApplePayButton extends PayButton {
 
   @override
   late final Widget _payButton = _applePayButton;
+
+  @override
+  final bool _returnsPaymentDataSynchronously = true;
 }

--- a/pay/lib/src/widgets/google_pay_button.dart
+++ b/pay/lib/src/widgets/google_pay_button.dart
@@ -88,7 +88,9 @@ class _GooglePayButtonState extends _PayButtonState {
   void _startListeningForPaymentResults() {
     _paymentResultSubscription = eventChannel
         .receiveBroadcastStream()
-        .map((result) => jsonDecode(result as String) as Map<String, dynamic>)
+        .cast<String>()
+        .map(jsonDecode)
+        .cast<Map<String, dynamic>>()
         .listen(widget._deliverPaymentResult, onError: widget._deliverError);
   }
 

--- a/pay/lib/src/widgets/google_pay_button.dart
+++ b/pay/lib/src/widgets/google_pay_button.dart
@@ -89,11 +89,7 @@ class _GooglePayButtonState extends _PayButtonState {
     _paymentResultSubscription = eventChannel
         .receiveBroadcastStream()
         .map((result) => jsonDecode(result as String) as Map<String, dynamic>)
-        .listen((result) {
-      widget._deliverPaymentResult(result);
-    }, onError: (error) {
-      widget._deliverError(error);
-    });
+        .listen(widget._deliverPaymentResult, onError: widget._deliverError);
   }
 
   @override

--- a/pay/lib/src/widgets/google_pay_button.dart
+++ b/pay/lib/src/widgets/google_pay_button.dart
@@ -68,7 +68,7 @@ class GooglePayButton extends PayButton {
   late final Widget _payButton = _googlePayButton;
 
   @override
-  final bool _returnsPaymentDataSynchronously = false;
+  final bool _collectPaymentResultSynchronously = false;
 
   @override
   State<PayButton> createState() => _GooglePayButtonState();

--- a/pay/lib/src/widgets/pay_button.dart
+++ b/pay/lib/src/widgets/pay_button.dart
@@ -27,7 +27,7 @@ part of '../../pay.dart';
 /// method which starts the payment process.
 abstract class PayButton extends StatefulWidget {
   /// A resident client to issue requests against the APIs.
-  late final Pay _payClient;
+  final Pay _payClient;
 
   /// Specifies the payment provider supported by the button
   final PayProvider buttonProvider;

--- a/pay/lib/src/widgets/pay_button.dart
+++ b/pay/lib/src/widgets/pay_button.dart
@@ -65,6 +65,14 @@ abstract class PayButton extends StatefulWidget {
     this.loadingIndicator,
   }) : _payClient = Pay({buttonProvider: paymentConfiguration});
 
+  /// Determines the list of supported platforms for the button.
+  List<TargetPlatform> get _supportedPlatforms;
+
+  /// Accessor for the widget to show as the payment button.
+  ///
+  /// This method returns a [Widget] that is conditionally shown based on the
+  /// result of the `isReadyToPay` request.
+  Widget get _payButton;
 
   /// Defines the strategy to return payment data information to the caller.
   ///
@@ -72,6 +80,14 @@ abstract class PayButton extends StatefulWidget {
   /// payment result is returned right after calling [Pay.showPaymentSelector]
   /// or rather received through asynchronous means (e.g.: an event stream).
   bool get _returnsPaymentDataSynchronously;
+
+  /// Determines whether the current platform is supported by the button.
+  bool get _isPlatformSupported =>
+      _supportedPlatforms.contains(defaultTargetPlatform);
+
+  @override
+  State<PayButton> createState() => _PayButtonState();
+
   /// Callback function to respond to tap events.
   ///
   /// This is the default function for tap events. Calls the [onPressed]
@@ -91,24 +107,10 @@ abstract class PayButton extends StatefulWidget {
     };
   }
 
-  /// Determines the list of supported platforms for the button.
-  List<TargetPlatform> get _supportedPlatforms;
-
-  /// Accessor for the widget to show as the payment button.
-  ///
-  /// This method returns a [Widget] that is conditionally shown based on the
-  /// result of the `isReadyToPay` request.
-  Widget get _payButton;
-
-  /// Determines whether the current platform is supported by the button.
-  bool get _isPlatformSupported =>
-      _supportedPlatforms.contains(defaultTargetPlatform);
   void _deliverPaymentResult(Map<String, dynamic> result) {
     onPaymentResult?.call(result);
   }
 
-  @override
-  State<PayButton> createState() => _PayButtonState();
   void _deliverError(error) {
     onError?.call(error);
   }

--- a/pay/lib/src/widgets/pay_button.dart
+++ b/pay/lib/src/widgets/pay_button.dart
@@ -79,7 +79,7 @@ abstract class PayButton extends StatefulWidget {
   /// This field is defined by implementations of this class to determine if the
   /// payment result is returned right after calling [Pay.showPaymentSelector]
   /// or rather received through asynchronous means (e.g.: an event stream).
-  bool get _returnsPaymentDataSynchronously;
+  bool get _collectPaymentResultSynchronously;
 
   /// Determines whether the current platform is supported by the button.
   bool get _isPlatformSupported =>
@@ -100,7 +100,7 @@ abstract class PayButton extends StatefulWidget {
       try {
         final result =
             await _payClient.showPaymentSelector(buttonProvider, paymentItems);
-        if (_returnsPaymentDataSynchronously) _deliverPaymentResult(result);
+        if (_collectPaymentResultSynchronously) _deliverPaymentResult(result);
       } catch (error) {
         _deliverError(error);
       }

--- a/pay/lib/src/widgets/pay_button.dart
+++ b/pay/lib/src/widgets/pay_button.dart
@@ -124,9 +124,9 @@ abstract class PayButton extends StatefulWidget {
 /// [_payButton] is added to the tree. Otherwise, if set, the replacement widget
 /// in [childOnError] is shown.
 class _PayButtonState extends State<PayButton> {
-  late final Future<bool> userCanPayFuture;
+  late final Future<bool> _userCanPayFuture;
 
-  Future<bool> userCanPay() async {
+  Future<bool> _userCanPay() async {
     try {
       return await widget._payClient.userCanPay(widget.buttonProvider);
     } catch (error) {
@@ -138,7 +138,7 @@ class _PayButtonState extends State<PayButton> {
   @override
   void initState() {
     super.initState();
-    userCanPayFuture = userCanPay();
+    _userCanPayFuture = _userCanPay();
   }
 
   @override
@@ -150,7 +150,7 @@ class _PayButtonState extends State<PayButton> {
     // Future builder running the `userCanPayFuture` and decides what to show
     // based on the result.
     return FutureBuilder<bool>(
-      future: userCanPayFuture,
+      future: _userCanPayFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.done) {
           if (snapshot.data == true) {

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/GooglePayHandler.kt
@@ -26,6 +26,7 @@ import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
 import com.google.android.gms.wallet.PaymentsClient
 import com.google.android.gms.wallet.Wallet
+import io.flutter.plugin.common.EventChannel.EventSink
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugins.pay_android.util.PaymentsUtil
@@ -47,7 +48,8 @@ private const val LOAD_PAYMENT_DATA_REQUEST_CODE = 991
  */
 class GooglePayHandler(private val activity: Activity) : PluginRegistry.ActivityResultListener {
 
-    private lateinit var loadPaymentDataResult: Result
+    // The stream sink that relays messages back to the Flutter end
+    private var paymentResultEvents: EventSink? = null
 
     companion object {
 
@@ -101,6 +103,12 @@ class GooglePayHandler(private val activity: Activity) : PluginRegistry.Activity
             activity, Wallet.WalletOptions.Builder().setEnvironment(environmentConstant).build()
         )
     }
+
+    /**
+     * Sets or unsets a new value for the stream sink to deliver messages back to Flutter.
+     */
+    fun setPaymentResultEventSink(eventSink: EventSink?) {
+        paymentResultEvents = eventSink
     }
 
     /**
@@ -150,10 +158,6 @@ class GooglePayHandler(private val activity: Activity) : PluginRegistry.Activity
     fun loadPaymentData(
         paymentProfileString: String, paymentItems: List<Map<String, Any?>>
     ) {
-
-        // Update the member to call the result when the operation completes
-        loadPaymentDataResult = result
-
         val paymentProfile = buildPaymentProfile(paymentProfileString, paymentItems)
         val client = paymentClientForProfile(paymentProfile)
         val ldpRequest = PaymentDataRequest.fromJson(paymentProfile.toString())

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
@@ -83,7 +83,7 @@ class PayMethodCallHandler private constructor(
                         arguments.getValue("payment_profile") as String,
                         arguments.getValue("payment_items") as List<Map<String, Any?>>
                     )
-                    result.success("")
+                    result.success("{}")
                 } else {
                     result.error(
                         "illegalEventChannelState",

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayMethodCallHandler.kt
@@ -25,7 +25,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-private const val METHOD_CHANNEL_NAME = "plugins.flutter.io/pay_channel"
+private const val METHOD_CHANNEL_NAME = "plugins.flutter.io/pay"
 
 private const val METHOD_USER_CAN_PAY = "userCanPay"
 private const val METHOD_SHOW_PAYMENT_SELECTOR = "showPaymentSelector"

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayPlugin.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/PayPlugin.kt
@@ -34,7 +34,8 @@ class PayPlugin : FlutterPlugin, ActivityAware {
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         this.flutterPluginBinding = flutterPluginBinding
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
-            googlePayButtonViewType, PayButtonViewFactory(flutterPluginBinding.binaryMessenger))
+            googlePayButtonViewType, PayButtonViewFactory(flutterPluginBinding.binaryMessenger)
+        )
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) = Unit
@@ -46,7 +47,7 @@ class PayPlugin : FlutterPlugin, ActivityAware {
     override fun onDetachedFromActivity() = methodCallHandler.stopListening()
 
     override fun onReattachedToActivityForConfigChanges(
-            activityPluginBinding: ActivityPluginBinding,
+        activityPluginBinding: ActivityPluginBinding,
     ) = onAttachedToActivity(activityPluginBinding)
 
     override fun onDetachedFromActivityForConfigChanges() = onDetachedFromActivity()

--- a/pay_ios/ios/Classes/PayPlugin.swift
+++ b/pay_ios/ios/Classes/PayPlugin.swift
@@ -20,7 +20,8 @@ import UIKit
 
 /// A class that receives and handles calls from Flutter to complete the payment.
 public class PayPlugin: NSObject, FlutterPlugin {
-  private static let methodChannelName = "plugins.flutter.io/pay_channel"
+  private static let methodChannelName = "plugins.flutter.io/pay"
+  
   private let methodUserCanPay = "userCanPay"
   private let methodShowPaymentSelector = "showPaymentSelector"
   

--- a/pay_platform_interface/lib/pay_channel.dart
+++ b/pay_platform_interface/lib/pay_channel.dart
@@ -33,9 +33,8 @@ import 'pay_platform_interface.dart';
 ///     configuration, paymentItems);
 /// ```
 class PayMethodChannel extends PayPlatform {
-  // The channel used to send messages down the native pipe.
-  final MethodChannel _channel =
-      const MethodChannel('plugins.flutter.io/pay_channel');
+  // The method channel used to send messages down the native pipe.
+  final MethodChannel _channel = const MethodChannel('plugins.flutter.io/pay');
 
   /// Determines whether a user can pay with the provider in the configuration.
   ///

--- a/pay_platform_interface/test/pay_channel_test.dart
+++ b/pay_platform_interface/test/pay_channel_test.dart
@@ -24,7 +24,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late final PayMethodChannel mobilePlatform;
-  const channel = MethodChannel('plugins.flutter.io/pay_channel');
+  const channel = MethodChannel('plugins.flutter.io/pay');
 
   const providerApplePay = PayProvider.apple_pay;
   final payConfigString =


### PR DESCRIPTION
This change adds functionality to allow diverse communications channels between the platforms supported. 

The existing relationship between Android's activity lifecycle and the Flutter engine is loose, and activity recreation events (for activity-aware plugins) re-creates the engine and all its bindings (e.g.: the data channel between the native and dart ends). There's been proposals to circumvent this limitation (see [`image_picker`'s proposal](https://pub.dev/packages/image_picker#handling-mainactivity-destruction-on-android)). This approach prefers to open up a channel between Flutter and the native end as soon as the widget is added to the tree, such that, if the main activity hosting the widget's action is destroyed, the new instance will pick up from where the last left.

This fixes #277, #274, #261, #206, and addresses #278 and #276.

The change includes:
- Enable multiple channel implementations per platform
- Use an event channel for Android
- Update method channel name