### PR TITLE
Add meeza support as payment network

### DIFF
--- a/pay_ios/ios/Classes/PaymentExtensions.swift
+++ b/pay_ios/ios/Classes/PaymentExtensions.swift
@@ -163,6 +163,9 @@ extension PKPaymentNetwork {
     case "girocard":
       guard #available(iOS 14.0, *) else { return nil }
       return .girocard
+    case "meeza":
+      guard #available(iOS 17.0, *) else { return nil }
+      return .meeza
     default:
       return nil
     }


### PR DESCRIPTION
Apple Pay has been launched in Egypt, and some types of our bank cards, such as **meeza** are supported.