### PR TITLE
Removed async DispatchQueue when closing Apple Pay modal

### DIFF
--- a/pay_ios/ios/Classes/PaymentHandler.swift
+++ b/pay_ios/ios/Classes/PaymentHandler.swift
@@ -194,17 +194,13 @@ extension PaymentHandler: PKPaymentAuthorizationControllerDelegate {
   }
   
   func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
-    controller.dismiss {
-      DispatchQueue.main.async {
-        // There was no attempt to authorize.
-        if self.paymentHandlerStatus == .presented {
-          self.paymentResult(FlutterError(code: "paymentCanceled", message: "User canceled payment authorization", details: nil))
-        }
-        // Authorization started, but it did not succeed
-        if self.paymentHandlerStatus == .authorizationStarted {
-          self.paymentResult(FlutterError(code: "paymentFailed", message: "Failed to complete the payment", details: nil))
-        }
-      }
+    controller.dismiss()
+    // There was no attempt to authorize.
+    if self.paymentHandlerStatus == .presented {
+      self.paymentResult(FlutterError(code: "paymentCanceled", message: "User canceled payment authorization", details: nil))
     }
-  }
+    // Authorization started, but it did not succeed
+    if self.paymentHandlerStatus == .authorizationStarted {
+      self.paymentResult(FlutterError(code: "paymentFailed", message: "Failed to complete the payment", details: nil))
+    }
 }


### PR DESCRIPTION
We had a problem with Apple Pay in our app where the Flutter app would be stuck in `AppLifecycleState.paused ` and therefore appear "frozen" to the user if the user canceled payment (sometimes also when the user completed the purchase). That happened to us on one device, iPhone 11 (iOS 18.1.1), when building the app in the release mode with Flutter 3.19.6 and Flutter 3.24.5 (we haven't tested it yet with the latest Flutter version). 

I'm not too good, and I haven't even written iOS code professionally before, but I came up with this solution, which solves our problem. I don't know if this is good practice, but I wanted to share the fix and hear some constructive comments on whether this is good or bad.
