### PR TITLE
Bring back test:rules to 1.6.1

### DIFF
--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -77,6 +77,6 @@ dependencies {
 
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test:rules:1.6.2'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }


### PR DESCRIPTION
The rules dependency was upgraded to 1.6.2 by mistake (this version does not exist yet).
This PR updates the version of this dep to 1.6.1, the latest available in GA.