### PR TITLE
Add PIX support

### DIFF
--- a/pay/example/android/app/build.gradle
+++ b/pay/example/android/app/build.gradle
@@ -29,7 +29,7 @@ android {
 
     defaultConfig {
         applicationId 'io.flutter.plugins.pay_example'
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pay_android/android/build.gradle
+++ b/pay_android/android/build.gradle
@@ -58,7 +58,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
     }
 
     lintOptions {
@@ -67,16 +67,16 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-wallet:19.4.0'
+    implementation 'com.google.android.gms:play-services-wallet:19.5.0'
 
-    testImplementation 'androidx.test.ext:truth:1.6.0'
-    testImplementation 'androidx.test.ext:junit:1.2.1'
+    testImplementation 'androidx.test.ext:truth:1.7.0'
+    testImplementation 'androidx.test.ext:junit:1.3.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-inline:5.1.0'
-    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.robolectric:robolectric:4.16'
 
-    androidTestImplementation 'androidx.test:core:1.6.1'
-    androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test:rules:1.6.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test:core:1.7.0'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test:rules:1.7.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/view/PayButtonView.kt
+++ b/pay_android/android/src/main/kotlin/io/flutter/plugins/pay_android/view/PayButtonView.kt
@@ -93,6 +93,7 @@ class ButtonTypeFactory {
             "order" -> ButtonType.ORDER
             "plain" -> ButtonType.PLAIN
             "subscribe" -> ButtonType.SUBSCRIBE
+            "pix" -> ButtonType.PIX
             else -> ButtonType.BUY
         }
     }

--- a/pay_android/lib/src/widgets/google_pay_button.dart
+++ b/pay_android/lib/src/widgets/google_pay_button.dart
@@ -23,7 +23,8 @@ enum GooglePayButtonType {
   order,
   pay,
   plain,
-  subscribe
+  subscribe,
+  pix
 }
 
 /// The button themes supported on Google Pay.
@@ -166,6 +167,7 @@ extension on GooglePayButtonType {
         GooglePayButtonType.subscribe: 'subscribe',
         GooglePayButtonType.pay: 'pay',
         GooglePayButtonType.order: 'order',
+        GooglePayButtonType.pix: 'pix',
       }[this]!;
 }
 


### PR DESCRIPTION
**Describe the changes proposed**<br>
Add the support for PIX payments with Google Pay.

**Additional context**<br>
PIX is a brazilian instantaneous payment method.
